### PR TITLE
Fixes for Night Vision

### DIFF
--- a/LowVisibility/LowVisibility/Helper/NightVisionHelper.cs
+++ b/LowVisibility/LowVisibility/Helper/NightVisionHelper.cs
@@ -1,0 +1,18 @@
+﻿namespace LowVisibility.Helper
+{
+    public class NightVisionHelper
+    {
+
+        public static void EnableNightVisionMode()
+        {
+            Mod.Log.Info?.Write($"Enabling night vision mode.");   
+            ModState.IsNightVisionMode = true;
+        }
+
+        public static void DisableNightVisionMode()
+        {
+            Mod.Log.Info?.Write($"Disabling night vision mode.");
+            ModState.IsNightVisionMode = false;
+        }
+    }
+}

--- a/LowVisibility/LowVisibility/Helper/SelectedActorHelper.cs
+++ b/LowVisibility/LowVisibility/Helper/SelectedActorHelper.cs
@@ -24,12 +24,17 @@ namespace LowVisibility.Helper
                 EWState actorState = new EWState(actor);
                 if (actorState.HasNightVision() && ModState.GetMapConfig().isDark)
                 {
-                    Mod.Log.Info?.Write($"Enabling night vision mode.");
-                    VfxHelper.EnableNightVisionEffect(actor);
+                    NightVisionHelper.EnableNightVisionMode();
+                    VfxHelper.EnableNightVisionEffect();
                 }
                 else
                 {
                     if (ModState.IsNightVisionMode)
+                    {
+                        NightVisionHelper.DisableNightVisionMode();
+                    }
+                    // Could probably be included in above if-statement, but keeping it separate just in case
+                    if (ModState.IsNightVisionEffect)
                     {
                         VfxHelper.DisableNightVisionEffect();
                     }

--- a/LowVisibility/LowVisibility/Helper/VfxHelper.cs
+++ b/LowVisibility/LowVisibility/Helper/VfxHelper.cs
@@ -270,13 +270,15 @@ namespace LowVisibility.Helper
             }
         }
 
-        public static void EnableNightVisionEffect(AbstractActor source)
+        public static void EnableNightVisionEffect()
         {
             // Skip if the green effect is disabled
             if (!Mod.Config.Toggles.ShowNightVision) { return; }
 
-            ModState.IsNightVisionMode = true;
+            Mod.Log.Debug?.Write($"Enabling night vision effect.");
 
+            ModState.IsNightVisionEffect = true;
+            
             MoodController mc = MoodController.Instance;
 
             PostProcessingBehaviour ppb = mc.unityPostProcess;
@@ -314,8 +316,10 @@ namespace LowVisibility.Helper
             // Skip if the green effect is disabled
             if (!Mod.Config.Toggles.ShowNightVision) { return; }
 
-            ModState.IsNightVisionMode = false;
-
+            Mod.Log.Debug?.Write($"Disabling night vision effect.");
+            
+            ModState.IsNightVisionEffect = false;
+            
             MoodController mc = BattleTech.Rendering.Mood.MoodController.Instance;
 
             // Grain will disable automatically

--- a/LowVisibility/LowVisibility/ModState.cs
+++ b/LowVisibility/LowVisibility/ModState.cs
@@ -15,6 +15,7 @@ namespace LowVisibility
         public static AbstractActor LastPlayerActorActivated;
         public static bool TurnDirectorStarted = false;
         public static bool IsNightVisionMode = false;
+        public static bool IsNightVisionEffect = false;
 
         // Gaussian probabilities
         public const int ResultsToPrecalcuate = 16384;

--- a/LowVisibility/LowVisibility/Patch/AbstractActorPatches.cs
+++ b/LowVisibility/LowVisibility/Patch/AbstractActorPatches.cs
@@ -93,27 +93,27 @@ namespace LowVisibility.Patch
                 __instance.Combat.MessageCenter.PublishMessage(message);
             }
 
-            // If friendly, reset the map visibility 
-            if (__instance.TeamId != __instance.Combat.LocalPlayerTeamGuid &&
-                __instance.Combat.HostilityMatrix.IsLocalPlayerFriendly(__instance.TeamId))
+            // If player unit, Night Vision logic is handled by SelectedActorHelper instead
+            if (__instance.TeamId != __instance.Combat.LocalPlayerTeamGuid)
             {
-                Mod.Log.Info?.Write($"{CombatantUtils.Label(__instance)} IS FRIENDLY, REBUILDING FOG OF WAR");
+                // If friendly, reset the map visibility and enable night vision mode and effects
+                if (__instance.Combat.HostilityMatrix.IsLocalPlayerFriendly(__instance.TeamId))
+                {
+                    Mod.Log.Info?.Write($"{CombatantUtils.Label(__instance)} IS FRIENDLY, REBUILDING FOG OF WAR");
 
-                if (actorState.HasNightVision() && ModState.GetMapConfig().isDark)
-                {
-                    Mod.Log.Info?.Write($"Enabling night vision mode.");
-                    VfxHelper.EnableNightVisionEffect(__instance);
-                }
-                else
-                {
-                    // TODO: This is likely never triggered due to the patch below... remove?
-                    if (ModState.IsNightVisionMode)
+                    if (actorState.HasNightVision() && ModState.GetMapConfig().isDark)
                     {
-                        VfxHelper.DisableNightVisionEffect();
+                        NightVisionHelper.EnableNightVisionMode();
+                        VfxHelper.EnableNightVisionEffect();
                     }
-                }
 
-                VfxHelper.RedrawFogOfWar(__instance);
+                    VfxHelper.RedrawFogOfWar(__instance);
+                }
+                // If not friendly, only enable the night vision mode for bonus effects
+                else if (actorState.HasNightVision() && ModState.GetMapConfig().isDark)
+                {
+                    NightVisionHelper.EnableNightVisionMode();                
+                }
             }
         }
     }
@@ -132,7 +132,14 @@ namespace LowVisibility.Patch
             if (__instance != null)
             {
                 // Disable night vision 
-                if (ModState.IsNightVisionMode) VfxHelper.DisableNightVisionEffect();
+                if (ModState.IsNightVisionMode)
+                {
+                    NightVisionHelper.DisableNightVisionMode();
+                }
+                if (ModState.IsNightVisionEffect)
+                {
+                    VfxHelper.DisableNightVisionEffect();
+                }
 
             }
         }

--- a/LowVisibility/LowVisibility/Patch/NightVisionPatches.cs
+++ b/LowVisibility/LowVisibility/Patch/NightVisionPatches.cs
@@ -11,7 +11,7 @@ namespace LowVisibility.Patch
         {
             if (!__runOriginal) return;
 
-            if (ModState.IsNightVisionMode)
+            if (ModState.IsNightVisionEffect)
             {
                 __result = true;
                 __runOriginal = false;
@@ -27,7 +27,7 @@ namespace LowVisibility.Patch
         {
             if (!__runOriginal) return;
 
-            if (ModState.IsNightVisionMode)
+            if (ModState.IsNightVisionEffect)
             {
                 __result = true;
                 __runOriginal = false;
@@ -43,7 +43,7 @@ namespace LowVisibility.Patch
         {
             if (!__runOriginal) return;
 
-            if (ModState.IsNightVisionMode)
+            if (ModState.IsNightVisionEffect)
             {
                 __result = true;
                 __runOriginal = false;
@@ -59,7 +59,7 @@ namespace LowVisibility.Patch
         {
             if (!__runOriginal) return;
 
-            if (ModState.IsNightVisionMode)
+            if (ModState.IsNightVisionEffect)
             {
                 __result = true;
                 __runOriginal = false;


### PR DESCRIPTION
* Split Night Vision mode and effect into two different states, where effect is the green overlay and mode is the stat bonuses
* Fixed issue with Night Vision bonuses only being applied if the overlay effect was enabled, which can be an install option
* Added support for enemy AI units being able to enable Night Vision mode
